### PR TITLE
Make the markdown slides separators Windows friendly.

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,8 +24,8 @@
       <div class="slides">
         <section
           data-markdown="content.md"
-          data-separator="\n------\n"
-          data-separator-vertical="\n---\n"
+          data-separator="\r?\n------\r?\n"
+          data-separator-vertical="\r?\n---\r?\n"
           data-separator-notes="<!-- NOTES -->"></section>
       </div>
     </div>


### PR DESCRIPTION
When cloned in Windows, the line-endings are automatically converted to `\r\n`, so the separators were not detected correctly.